### PR TITLE
Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: clojure
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+matrix:
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Muse
 
+[![Build Status](https://travis-ci.org/kachayev/muse.svg?branch=master)](https://travis-ci.org/kachayev/muse)
+
 *Muse* is a Clojure library that works hard to make your relationship with remote data simple & enjoyable. We believe that concurrent code can be elegant and efficient at the same time.
 
 Often times your business logic relies on remote data that you need to fetch from different sources: databases, caches, web services or 3rd party APIs, and you can't mess things up. *Muse* helps you to keep your business logic clear of low-level details while performing efficiently:


### PR DESCRIPTION
:information_desk_person: This changeset adds an initial [Travis CI](https://travis-ci.org) configuration for  running this project as a build matrix against multiple JDK versions, from multiple vendors.