### PR TITLE
Fix incorrect handling of `DataSource`'s by `value`

### DIFF
--- a/src/muse/core.cljc
+++ b/src/muse/core.cljc
@@ -131,7 +131,7 @@
 (deftype MuseMap [f values]
   proto/Context
   (get-context [_] ast-monad)
-  
+
   ComposedAST
   (compose-ast [_ f2] (MuseMap. (comp f2 f) values))
 
@@ -189,7 +189,7 @@
 
 (defn value
   [v]
-  (if (satisfies? DataSource value)
+  (if (satisfies? DataSource v)
     (MuseValue. v)
     (MuseDone. v)))
 

--- a/src/muse/core.cljc
+++ b/src/muse/core.cljc
@@ -147,10 +147,14 @@
   Object
   (toString [_] (str "(" f " " (print-childs values) ")")))
 
+(defn- ast?
+  [ast]
+  (or (satisfies? MuseAST ast)
+      (satisfies? DataSource ast)))
+
 (defn assert-ast!
   [ast]
-  (assert (or (satisfies? MuseAST ast)
-              (satisfies? DataSource ast))))
+  (assert (ast? ast)))
 
 (deftype MuseFlatMap [f values]
   proto/Context
@@ -189,9 +193,9 @@
 
 (defn value
   [v]
-  (if (satisfies? DataSource v)
-    (MuseValue. v)
-    (MuseDone. v)))
+  (assert (not (ast? v))
+          (str "The value is already an AST: " v))
+  (MuseDone. v))
 
 (defn fmap
   [f muse & muses]

--- a/test/muse/core_spec.cljc
+++ b/test/muse/core_spec.cljc
@@ -64,8 +64,14 @@
 
 (deftest recur-with-value
   (assert-ast 10 (muse/value 10))
-  (assert-ast 5 (flat-map recur-next (Single. 0)))
-  (assert-ast 5 (flat-map recur-next (muse/value (Single. 0)))))
+  (assert-ast 5 (flat-map recur-next (Single. 0))))
+
+(defn- assert-failed? [f]
+  (is (thrown? #?(:clj AssertionError :cljs js/Error) (f))))
+
+(deftest value-from-ast
+  (assert-failed? #(muse/value (Single. 0)))
+  (assert-failed? #(muse/value (fmap inc (muse/value 0)))))
 
 ;; attention! never do such mutations within "fetch" in real code
 (defrecord Trackable [tracker seed]

--- a/test/muse/core_spec.cljc
+++ b/test/muse/core_spec.cljc
@@ -64,7 +64,8 @@
 
 (deftest recur-with-value
   (assert-ast 10 (muse/value 10))
-  (assert-ast 5 (flat-map recur-next (Single. 0))))
+  (assert-ast 5 (flat-map recur-next (Single. 0)))
+  (assert-ast 5 (flat-map recur-next (muse/value (Single. 0)))))
 
 ;; attention! never do such mutations within "fetch" in real code
 (defrecord Trackable [tracker seed]


### PR DESCRIPTION
Currently `value` produces `MuseDone` instance regardless of the nature of the passed argument.
