### PR TITLE
Make it possible to apply flat-map to MuseDone values

### DIFF
--- a/src/muse/core.cljc
+++ b/src/muse/core.cljc
@@ -131,7 +131,7 @@
 (deftype MuseMap [f values]
   proto/Context
   (get-context [_] ast-monad)
-  
+
   ComposedAST
   (compose-ast [_ f2] (MuseMap. (comp f2 f) values))
 
@@ -250,7 +250,10 @@
    (loop [ast-node ast cache {}]
      (let [fetches (next-level ast-node)]
        (if (not (seq fetches))
-         (:value ast-node) ;; xxx: should be MuseDone, assert & throw exception otherwise
+         ;; xxx: should be MuseDone, assert & throw exception otherwise
+         (if (done? ast-node)
+           (:value ast-node)
+           (recur (inject-into {:cache cache} ast-node) cache))
          (let [by-type (group-by resource-name fetches)
                ;; xxx: catch & propagate exceptions
                fetch-groups (<! (async/map vector (map fetch-group by-type)))

--- a/test/muse/core_spec.cljc
+++ b/test/muse/core_spec.cljc
@@ -32,6 +32,8 @@
 
 (defn- sum-pair [[a b]] (+ a b))
 
+(defn- id [v] (muse/value v))
+
 (defn- assert-ast
   ([expected ast] (assert-ast expected ast nil))
   ([expected ast callback]
@@ -48,8 +50,12 @@
   (assert-ast 30 (fmap count (DList. 30)))
   (assert-ast 40 (fmap inc (fmap count (DList. 39))))
   (assert-ast 50 (fmap count (fmap concat (DList. 30) (DList. 20))))
+  (assert-ast 42 (flat-map id (Single. 42)))
+  (assert-ast 42 (flat-map id (muse/value 42)))
   (assert-ast [15 15] (flat-map mk-pair (Single. 15)))
-  (assert-ast 60 (fmap sum-pair (flat-map mk-pair (Single. 30)))))
+  (assert-ast [15 15] (flat-map mk-pair (muse/value 15)))
+  (assert-ast 60 (fmap sum-pair (flat-map mk-pair (Single. 30))))
+  (assert-ast 60 (fmap sum-pair (flat-map mk-pair (muse/value 30)))))
 
 (deftest higher-level-api
   (assert-ast [0 1] (muse/collect [(Single. 0) (Single. 1)]))


### PR DESCRIPTION
Currently `flat-map` returns `nil` in case passed AST is an instance of `MuseDone` or contains instance of it as an only leaf:

``` clojure
muse.core-spec> (muse/run!! (muse/flat-map (fn [x] (muse/value x)) (muse/value 42)))
nil
muse.core-spec> (muse/run!! (muse/flat-map mk-pair  (muse/fmap inc (muse/value 42))))
nil
```

Is it an intended behavior?

In case it _should_ work, sort of a fix is attached, but I'm not entirely sure it's correct. At least, test cases could be used to reproduce the problem.
