### PR TITLE
Adapt to cats 1.0.0 changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,8 +24,8 @@
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                                  [cats "0.4.0"]
+                                  [funcool/cats "1.0.0"]
                                   [org.clojure/clojurescript "0.0-3308"]]
                    :plugins [[lein-cljsbuild "1.0.6"]]}}
-  
+
   :signing {:gpg-key "kachayev@gmail.com"})

--- a/test/muse/cats_spec.cljc
+++ b/test/muse/cats_spec.cljc
@@ -3,13 +3,15 @@
      (:require [clojure.test :refer (deftest is)]
                [clojure.core.async :refer (go <!!) :as a]
                [muse.core :as muse]
-               [cats.core :as m])
+               [cats.core :as m]
+               [cats.context :refer [with-context]])
      :cljs
      (:require [cljs.test :refer-macros (deftest is async)]
                [cljs.core.async :as a :refer (take!)]
                [muse.core :as muse]
                [cats.core :as m]))
-  #? (:cljs (:require-macros [cljs.core.async.macros :refer (go)]))
+  #? (:cljs (:require-macros [cljs.core.async.macros :refer (go)]
+                             [cats.context :refer (with-context)]))
   (:refer-clojure :exclude (run!)))
 
 (defrecord DList [size]
@@ -27,10 +29,10 @@
 (deftest cats-api
   (is (satisfies? muse/MuseAST (m/fmap count (muse/value (range 10)))))
   (is (satisfies? muse/MuseAST
-                  (m/with-monad muse/ast-monad
+                  (with-context muse/ast-monad
                     (m/fmap count (DList. 10)))))
   (is (satisfies? muse/MuseAST
-                  (m/with-monad muse/ast-monad
+                  (with-context muse/ast-monad
                     (m/bind (Single. 10) (fn [num] (Single. (inc num))))))))
 
 (defn assert-ast [expected ast-factory]


### PR DESCRIPTION
See [full changelog](https://github.com/funcool/cats/blob/master/CHANGELOG.md#version-100).

Now both Traversable and Applicative Do syntax are available in cats, your input at EuroClojure was really helpful! If you accept this PR we might want to add a notice to the README saying that only versions of cats above 1.0.0 are supported.