### PR TITLE
[RFC] [CLJ] Use Manifold instead of core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
                                    :pretty-print true}}]}
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
+                                  [manifold "0.1.0"]
                                   [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                                   [cats "0.4.0"]
                                   [org.clojure/clojurescript "0.0-3308"]]


### PR DESCRIPTION
This commit serves as a proof of concept of porting the Clojure version of
Muse to Manifold. See also #9.

All parts of the API which were returning or accepting core.async channels
are now relying on Manifold [deferreds][d].

The remote-req function from the quickstart example in README.md becomes:

```clojure
(require '[manifold.deferred :as d])

(defn remote-req [id result]
  (let [wait (rand 1000)]
    (println "-->" id ".." wait)
    (d/future
      (Thread/sleep wait)
      (println "<--" id)
      result)))
```

This patch breaks the ClojureScript version of Muse. With some extra
effort both the Clojure + Manfold and ClojureScript + core.async versions
could coexist, though.

I'd love to learn what do you think about this.

[d]: https://github.com/ztellman/manifold/blob/master/docs/deferred.md