### PR TITLE
Should ast-monad "export" be returned to the muse.core?

### DIFF
--- a/src/muse/core.cljc
+++ b/src/muse/core.cljc
@@ -8,6 +8,7 @@
                      [muse.protocol :as proto]))
   (:refer-clojure :exclude (run!)))
 
+(def ast-monad proto/ast-monad)
 (def fmap proto/fmap)
 (def flat-map proto/flat-map)
 (def value proto/value)

--- a/src/muse/deferred.clj
+++ b/src/muse/deferred.clj
@@ -4,6 +4,7 @@
             [cats.core :refer (with-monad)])
   (:refer-clojure :exclude (run!)))
 
+(def ast-monad proto/ast-monad)
 (def fmap proto/fmap)
 (def flat-map proto/flat-map)
 (def value proto/value)


### PR DESCRIPTION
Prior to 0.4.3-alpha `ast-monad` was [part of the public API](https://github.com/kachayev/muse/blob/5348cf47a25468ef7b936e1917c424aed8db0583/src/muse/core.cljc#L17) (it's not explicitly marked as private), so moving it to other namespace may break users' code (especially in case they use interoperability with `cats`). 

There is a [mention about API unstability in README](https://github.com/kachayev/muse/blob/master/README.md#usage), but I believe "exporting" `ast-monad` in same namespace as all other main API functions may still be a good idea. What are you thoughts about it?