### PR TITLE
Check if datasource returned from flat-map is already cached

### DIFF
--- a/src/muse/protocol.cljc
+++ b/src/muse/protocol.cljc
@@ -208,7 +208,7 @@
         (let [result (apply f (map :value next))]
           ;; xxx: refactor to avoid dummy leaves creation
           (if (satisfies? DataSource result)
-            (MuseMap. identity [result])
+            (MuseMap. identity [(cached-or env result)])
             result))
 
         :else

--- a/src/muse/protocol.cljc
+++ b/src/muse/protocol.cljc
@@ -148,8 +148,13 @@
 (defn print-childs [nodes]
   (s/join " " (map print-node nodes)))
 
+(defn node-done? [node]
+  (if (satisfies? DataSource node)
+    false
+    (done? node)))
+
 (defn ready? [next-level]
-  (empty? (remove done? next-level)))
+  (empty? (remove node-done? next-level)))
 
 (defn force-failed [nodes]
   (first (filter safe-fetch-failed? nodes)))
@@ -209,7 +214,7 @@
           ;; xxx: refactor to avoid dummy leaves creation
           (if (satisfies? DataSource result)
             (MuseMap. identity [(cached-or env result)])
-            result))
+            (inject-into env result)))
 
         :else
         (MuseFlatMap. f next))))


### PR DESCRIPTION
Currently there is but that cause the same resource being fetched twice if returned from flat-map
example: 
```
  (defrecord Foo [id]
    DataSource
    (fetch [_]
      (prn "Fetching" id)
      (d/success-deferred id)))


  (run!!
   (->>
    (->Foo 42)
    (flat-map
     (fn [x]
       (->Foo 42)))))
```

Current fix check first if it's cached before returning data source to next round